### PR TITLE
chore: bump craco dependancy version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "url": "https://github.com/jackwilsdon/craco-use-babelrc.git"
   },
   "dependencies": {
-    "@craco/craco": "^3.2.0"
+    "@craco/craco": "^6.4.3"
   }
 }


### PR DESCRIPTION
This resolves prototype pollution in older versions of lodash (which
craco depended on)

see https://github.com/jackwilsdon/craco-use-babelrc/issues/2

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Critical      │ Prototype Pollution in lodash                                │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash.mergewith                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.6.2                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @jackwilsdon/craco-use-babelrc [dev]                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @jackwilsdon/craco-use-babelrc > @craco/craco >              │
│               │ lodash.mergewith                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://github.com/advisories/GHSA-jf85-cpcp-j695            │
└───────────────┴──────────────────────────────────────────────────────────────┘

```